### PR TITLE
Async channel connection

### DIFF
--- a/src/RabbitConnection/index.ts
+++ b/src/RabbitConnection/index.ts
@@ -12,6 +12,7 @@ export default class RabbitConnection {
    * The connection
    */
   private $connection: Connection
+  private $connectionPromise: Promise<Connection>
 
   /**
    * The credentials
@@ -110,7 +111,10 @@ export default class RabbitConnection {
    */
   public async getConnection() {
     if (!this.$connection) {
-      this.$connection = await connect(this.url)
+      if (!this.$connectionPromise) {
+        this.$connectionPromise = connect(this.url);
+      }
+      this.$connection = await this.$connectionPromise;
     }
 
     return this.$connection


### PR DESCRIPTION
Hi! In current version of your package you can't use assertQueue in asynchronous manner, for example running this snippet results in error:
```js
await Promise.all(['q-1', 'q-2'].map(async e => {
  await Rabbit.assertQueue(e);
  const channel = await Rabbit.getChannel();
  channel.prefetch(1);
})); 
```
That's because you should store the channel promise only once and await for it, not create it each time you don't have ready channel. Also it is not a good idea to set hasChannel to true before we actually successfully created the channel.
Best Regards!